### PR TITLE
Missing dependency and CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: generic
+services:
+  - docker
+
+env:
+  matrix:
+    - ROS_DISTRO="melodic"
+
+install:
+  - git clone --quiet --depth 1 https://github.com/ros-industrial/industrial_ci.git .industrial_ci -b master
+script:
+  - .industrial_ci/travis.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,9 @@ services:
 
 env:
   global:
+    - BUILDER="catkin_make"
     - VERBOSE_TESTS="true"
-    - UPSTREAM_WORKSPACE='github:rarrais/rospy_urdf_to_rviz_converter#ros_package'
+    # - UPSTREAM_WORKSPACE='github:rarrais/rospy_urdf_to_rviz_converter#ros_package'
   matrix:
     - ROS_DISTRO="melodic"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ env:
   global:
     - BUILDER="catkin_make"
     - VERBOSE_TESTS="true"
-    # - UPSTREAM_WORKSPACE='github:rarrais/rospy_urdf_to_rviz_converter#ros_package'
+    - UPSTREAM_WORKSPACE='github:rarrais/rospy_urdf_to_rviz_converter#ros_package'
   matrix:
     - ROS_DISTRO="melodic"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ services:
 env:
   global:
     - VERBOSE_TESTS="true"
+    - UPSTREAM_WORKSPACE='github:rarrais/rospy_urdf_to_rviz_converter#ros_package'
   matrix:
     - ROS_DISTRO="melodic"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ services:
   - docker
 
 env:
+  global:
+    - VERBOSE_TESTS="true"
   matrix:
     - ROS_DISTRO="melodic"
 

--- a/atom_calibration/CMakeLists.txt
+++ b/atom_calibration/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(atom_calibration)
 
-find_package(catkin REQUIRED)
+find_package(catkin REQUIRED rostest)
 catkin_package()
 
 catkin_python_setup()
@@ -14,3 +14,6 @@ catkin_install_python(PROGRAMS
     DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 
+if (CATKIN_ENABLE_TESTING)
+  add_rostest(test/create_calibration_pkg.test)
+endif()

--- a/atom_calibration/scripts/create_calibration_pkg
+++ b/atom_calibration/scripts/create_calibration_pkg
@@ -4,6 +4,7 @@
 import os
 import argparse
 import subprocess
+import sys
 
 # 3rd-party
 import rospy
@@ -13,13 +14,13 @@ from colorama import Style, Fore
 from datetime import datetime
 
 # local packages
-from atom_core.utilities import resolvePath, execute
+from atom_core.utilities import resolvePath, execute, filterLaunchArguments
 
 if __name__ == "__main__":
     # Parse command line arguments
     ap = argparse.ArgumentParser()
     ap.add_argument("-n", "--name", help='package_name', type=str, required=True)
-    args = vars(ap.parse_args())
+    args = vars(ap.parse_args(args=filterLaunchArguments(sys.argv)))
 
     # Initial setup
     package_path = resolvePath(args['name'])  # full path to the package, including its name.

--- a/atom_calibration/test/create_calibration_pkg.test
+++ b/atom_calibration/test/create_calibration_pkg.test
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <launch>
 
-    <node name="create_calibration_pkg" pkg="atom_calibration" type="create_calibration_pkg" args="--name testing_robot" output="screen" />
+    <node name="create_calibration_pkg" pkg="atom_calibration" type="create_calibration_pkg" args="--name testing_robot" output="screen" required="true"/>
 
     <!-- Dumb test only to check if node executes -->
     <param name="/hztest/topic" value="rosout" />

--- a/atom_calibration/test/create_calibration_pkg.test
+++ b/atom_calibration/test/create_calibration_pkg.test
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <launch>
 
-    <node name="create_calibration_pkg" pkg="atom_calibration" type="create_calibration_pkg" args="--name test_robot" required="true"/>
+    <node name="create_calibration_pkg" pkg="atom_calibration" type="create_calibration_pkg" args="--name testing_robot" output="screen" />
 
     <!-- Dumb test only to check if node executes -->
     <param name="/hztest/topic" value="rosout" />

--- a/atom_calibration/test/create_calibration_pkg.test
+++ b/atom_calibration/test/create_calibration_pkg.test
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<launch>
+
+    <node name="create_calibration_pkg" pkg="atom_calibration" type="create_calibration_pkg" args="--name test_robot" required="true"/>
+
+    <!-- Dumb test only to check if node executes -->
+    <param name="/hztest/topic" value="rosout" />
+    <param name="/hztest/hz" value="0" />
+    <param name="/hztest/hzerror" value="0" />
+    <param name="/hztest/test_duration" value="2.0" />
+    <test test-name="hztest_test" pkg="rostest" type="hztest" name="hztest" />
+
+</launch>

--- a/atom_calibration/test/create_calibration_pkg.test
+++ b/atom_calibration/test/create_calibration_pkg.test
@@ -7,7 +7,7 @@
     <param name="/hztest/topic" value="rosout" />
     <param name="/hztest/hz" value="0" />
     <param name="/hztest/hzerror" value="0" />
-    <param name="/hztest/test_duration" value="2.0" />
+    <param name="/hztest/test_duration" value="0.1" />
     <test test-name="hztest_test" pkg="rostest" type="hztest" name="hztest" />
 
 </launch>


### PR DESCRIPTION
Hi!

Very interesting approach, @miguelriemoliveira  and team!

Tried running it on my system, found an unmet dependency while running the ```rosrun atom_calibration create_calibration_pkg --name <your_robot_calibration>``` command, following the [How to Use - Quick Start](https://github.com/lardemua/atom#how-to-use---quick-start) README guide:

```
Traceback (most recent call last):
  File "/home/ubuntu/catkin_ws/src/atom/atom_calibration/scripts/create_calibration_pkg", line 16, in <module>
    from atom_core.utilities import resolvePath, execute
  File "/home/ubuntu/catkin_ws/src/atom/atom_core/src/atom_core/utilities.py", line 36, in <module>
    from rospy_urdf_to_rviz_converter.rospy_urdf_to_rviz_converter import urdfToMarkerArray
ImportError: No module named rospy_urdf_to_rviz_converter.rospy_urdf_to_rviz_converter
```

Did a little search and found [this package](https://github.com/miguelriemoliveira/rospy_urdf_to_rviz_converter), which seemed to solve the issue, as I managed to create my robot calibration package successfully. Noticed, however, that is not a ROS Package, so I've [forked it](https://github.com/rarrais/rospy_urdf_to_rviz_converter), adapted it to be one, and then created a [PR](https://github.com/miguelriemoliveira/rospy_urdf_to_rviz_converter/pull/1).

I've also set up a [CI process](https://travis-ci.com/github/rarrais/atom) to try to identify this issue in this repo and track this runtime dependency. For the testing component, it is just a dumb test that signalizes if the node [can run](https://travis-ci.com/github/rarrais/atom/builds/176798553) or [if it cannot](https://travis-ci.com/github/rarrais/atom/builds/176798029) (therefore checking for the dependency).

I've created a PR with these changes. However, please note that it doesn't solve the dependency include issue (I'll leave that to the repository maintainers), but only adds the test and the CI infrastructure file. Furthermore, notice that the PR CI file depends on my fork. That should be altered if the [PR](https://github.com/miguelriemoliveira/rospy_urdf_to_rviz_converter/pull/1) at the rospy_urdf_to_rviz_converter repository is accepted. 

If you see value in adding a CI process to this repo, I can help you with that.
