### PR TITLE
Convert rosbag to ros1 if ros2 bag is passed

### DIFF
--- a/atom_calibration/scripts/configure_calibration_pkg
+++ b/atom_calibration/scripts/configure_calibration_pkg
@@ -29,6 +29,7 @@ from pytictoc import TicToc
 from atom_core.utilities import atomPrintOK, checkDirectoryExistence, atomError, atomStartupPrint, getJointParentChild, verifyAnchoredSensor
 from atom_core.naming import generateLabeledTopic
 from atom_core.system import execute
+from atom_core.rosbag2 import is_rosbag2, convert_rosbag2_to_rosbag1
 from colorama import Style, Fore
 from graphviz import Digraph
 from urdf_parser_py.urdf import URDF
@@ -115,8 +116,19 @@ if __name__ == "__main__":
     # Read the bag file
     # --------------------------------------------------------------------------
     bag_file, _, bag_file_rel = atom_core.config_io.uriReader(config['bag_file'])
-    print('Loading bagfile ' + Fore.BLUE + bag_file + Style.RESET_ALL)
-    bag = rosbag.Bag(bag_file)  # load the bag file
+    if is_rosbag2(bag_file):
+        print(f"{bag_file} is a rosbag2 file. Converting to rosbag1 format")
+        rosbag2_file = convert_rosbag2_to_rosbag1(bag_file)
+        if rosbag2_file:
+            print("Converted successfully, destination file: " + rosbag2_file)
+            bag_file = rosbag2_file
+            bag_file_rel = bag_file
+        else:
+            print('Error converting rosbag2 to rosbag1')
+            exit(1)
+
+    print('Loading bagfile ' + bag_file)
+    bag = rosbag.Bag(bag_file)
     bag_info = bag.get_type_and_topic_info()
     bag_types = bag_info[0]
     bag_topics = bag_info[1]

--- a/atom_core/src/atom_core/rosbag2.py
+++ b/atom_core/src/atom_core/rosbag2.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+"""
+rosbag2 format utilities
+"""
+import os
+from pathlib import Path
+
+from rosbags.convert.converter import convert_2to1
+
+def is_rosbag2(bag_path: str):
+    """
+    Check if a file is a rosbag2 file.
+    :param path: path to the file
+
+    :return: True if the file is a rosbag2 file, False otherwise
+    """
+
+    if os.path.isdir(bag_path):        
+        metadata_file = os.path.join(bag_path, 'metadata.yaml')
+        if os.path.exists(metadata_file):
+            return True
+        
+    return False
+
+
+def convert_rosbag2_to_rosbag1(bag_path: str):
+    """
+    Convert a rosbag2 file to a rosbag1 file.
+    :param path: path to the file
+
+    :return: path to the converted file or empty string if the conversion failed
+    """
+
+    src_path = Path(bag_path)
+    dst_path = Path(bag_path).with_suffix('.bag')
+    if dst_path.exists():
+        print(f"Destination file already exists: {dst_path.as_posix()}. Aborting conversion.")
+    else:
+        try:
+            convert_2to1(src_path, dst_path, [], [])
+        except Exception as e:
+            print(e)
+            return ""
+        
+    return dst_path.as_posix()

--- a/dockerfiles/noetic/Dockerfile
+++ b/dockerfiles/noetic/Dockerfile
@@ -1,0 +1,24 @@
+FROM osrf/ros:noetic-desktop-full-focal
+
+RUN useradd ros1
+
+# add password to ros1 user
+RUN echo "ros1:ros" | sudo chpasswd
+
+RUN usermod -a -G sudo ros1
+
+# install bootstrap tools
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    build-essential \
+    git \
+    python3-rosdep \
+    python3-pip \
+    python3-rosinstall \
+    python3-vcstools \
+    python3-tk \
+    && rm -rf /var/lib/apt/lists/*
+
+# install aditional dependencies
+RUN apt-get update && apt-get install -y vim \
+    ros-noetic-ros-numpy \
+    ros-noetic-rviz-visual-tools


### PR DESCRIPTION
As a ROS2 user, I've been using Atom for several months and I am super excited!

Here I added a conversion from rosbag2 format to rosbag1 so people can use their data recorded in ROS2 with Atom.

To make a conversion I use an external library [rosbags](https://github.com/cmrobotics/rosbags). That is a fork from [here](https://github.com/cmrobotics/rosbags). We do not use the upstream because of the [bug](https://gitlab.com/ternaris/rosbags/-/issues/52).

I'm happy to make a documentation page about setting up Atom for ROS2 users. Just not sure where to put it