### PR TITLE
Pass description file to rosbag launch

### DIFF
--- a/atom_calibration/templates/collect_data.launch
+++ b/atom_calibration/templates/collect_data.launch
@@ -56,6 +56,7 @@
         <arg name="bag_file" value="$(arg bag_file)"/>
         <arg name="bag_start" value="$(arg bag_start)"/>
         <arg name="bag_rate" value="$(arg bag_rate)"/>
+        <arg name="description_file" default="$(arg description_file)"/>
     </include>
     <!-- %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% -->
 


### PR DESCRIPTION
Currently, `description_file` argument isn't used anyhow in `collect_data.launch`, so why not to fix it :)

But my original motivation for that was due to the usage of Atom as an ROS 2 user.

Atom currently [copies](https://github.com/lardemua/atom/blob/0804f0ce45179472a5123cea06b479baaabf1c6a/atom_calibration/scripts/configure_calibration_pkg#L149) robot model xacro file from the path in the config file to the calibration package as `initial_estimate.urdf.xacro`.

It may break things for ROS2 users if xacro file has some xacro:include tags (either you specify include path relative to the current file (../urdf/wheel.xacro) or relative to the package ((find realsense_description)/urdf/camera.xacro)) because we are unable to install ROS2 description package into ROS1 container so if we try to build that xacro (`xacro <path_to_xacro>`) some of the includes won't be found.

From my experience with that problem, the only critical part in the code where things break is at Collect dataset (specifically in [playbag.launch](https://github.com/lardemua/atom/blob/0804f0ce45179472a5123cea06b479baaabf1c6a/atom_calibration/templates/playbag.launch#L57) when it tries to build xacro file).

With that change ROS 2 user can pass the xacro file directly to `collect_data.launch` and that will do it.