### PR TITLE
add a meta-package for the atom stack

### DIFF
--- a/atom/CMakeLists.txt
+++ b/atom/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(atom)
+find_package(catkin REQUIRED)
+catkin_metapackage()

--- a/atom/package.xml
+++ b/atom/package.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>atom</name>
+  <version>0.0.0</version>
+  <description>The atom package</description>
+
+  <maintainer email="pr2admin@todo.todo">pr2admin</maintainer>
+  <license>TODO</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <exec_depend>atom_calibration</exec_depend>
+  <exec_depend>atom_core</exec_depend>
+  <exec_depend>atom_evaluation</exec_depend>
+  <exec_depend>atom_msgs</exec_depend>
+  <exec_depend>selected_points_publisher</exec_depend>
+
+  <export>
+    <metapackage/>
+  </export>
+</package>


### PR DESCRIPTION
you probably want to edit this before merging, but a meta-package is nice to have to build the whole stack in a large workspace and install packages as `apt install ros-*-atom` once they are released.
