### PR TITLE
fixing #840

### DIFF
--- a/atom_core/src/atom_core/dataset_io.py
+++ b/atom_core/src/atom_core/dataset_io.py
@@ -157,7 +157,7 @@ def loadResultsJSON(json_file, collection_selection_function=None):
     if skipped_loading:  # list is not empty
         print('Skipped loading images and point clouds for collections: ' + str(skipped_loading) + '.')
 
-    return dataset
+    return dataset, json_file
 
 
 def saveAtomDataset(filename, dataset_in, save_data_files=True, freeze_dataset=False):


### PR DESCRIPTION
It's the fix for the problem described in issue #840. The evaluation script runs now without getting the ValueError.

I also checked and every time the `loadResultsJSON()` function is called in ATOM it is expected to return the 2 values and not just the dataset.