### PR TITLE
#899 Adding cross validation to ATOM

### DIFF
--- a/atom_batch_execution/experiments/rrbot_example/README.md
+++ b/atom_batch_execution/experiments/rrbot_example/README.md
@@ -1,0 +1,20 @@
+# RRBOT batch execution example
+
+In this script we will carry out the batch execution of two experiments using a RRBOT train dataset.
+
+We have three concepts which are important to understand what follows: an **experiment** is an execution of one or more atom scripts in sequence, with specific parameters given as command line arguments to those scripts. A experiment may have different **runs**, which are repetitions of an experiment with the same parameters expect for those related to randomness, i.e. the random seed of the experiment. These runs are then averaged out using the process_results script, in order to provide statistically significant results. Each run conducted will be divided in **folds**, which are dataset partitions used for cross-validation.
+Currently, fold creation is supported with StratifiedKFold, KFold, LeaveOneOut, and StratifiedShuffleSplit from scikit-learn.
+
+To run, first go to the the experiments/example
+
+    roscd atom_batch_execution/experiments/example/
+
+then do:
+
+    rosrun atom_batch_execution batch_execution -tf template.yml.j2 -df data.yml -of results -v -ow
+
+This will create a _results_ folder and put all runs inside. Finally, if you want to average the numerical cells in collected csv files you can use:
+
+    rosrun atom_batch_execution process_results -rf results/ -of results_processed -ow -v
+
+This command will average out all runs from the same experiments. The created folder _results_processed_, will contain experiments (instead of runs of experiments).

--- a/atom_batch_execution/experiments/rrbot_example/auto_rendered.yaml
+++ b/atom_batch_execution/experiments/rrbot_example/auto_rendered.yaml
@@ -1,0 +1,250 @@
+#
+#           █████╗ ████████╗ ██████╗ ███╗   ███╗
+#          ██╔══██╗╚══██╔══╝██╔═══██╗████╗ ████║
+#          ███████║   ██║   ██║   ██║██╔████╔██║
+#          ██╔══██║   ██║   ██║   ██║██║╚██╔╝██║
+#   __     ██║  ██║   ██║   ╚██████╔╝██║ ╚═╝ ██║    _
+#  / _|    ╚═╝  ╚═╝   ╚═╝    ╚═════╝ ╚═╝     ╚═╝   | |
+#  | |_ _ __ __ _ _ __ ___   _____      _____  _ __| | __
+#  |  _| '__/ _` | '_ ` _ \ / _ \ \ /\ / / _ \| '__| |/ /
+#  | | | | | (_| | | | | | |  __/\ v  v / (_) | |  |   <
+#  |_| |_|  \__,_|_| |_| |_|\___| \_/\_/ \___/|_|  |_|\_\
+#  https://github.com/lardemua/atom
+
+# this yml file contains a set of commands to be run in batch.
+# use jinja2 syntax for referencing variables
+
+# Preprocessing will run only once before all experiments.
+preprocessing:
+  cmd: |
+    ls /tmp
+
+# Define batches to run
+experiments:
+  
+    
+    
+      nig_0.1_run001_fold001:
+        cmd: |
+          rosrun atom_calibration calibrate -json $ATOM_DATASETS/rrbot/train/dataset.json \
+          -v -max_nfev 2 -ss 1 \
+          -nig 0.1 0.1 \
+          -csf 'lambda x: int(x) in [0, 3]' \
+          && \
+          rosrun atom_evaluation rgb_to_rgb_evaluation \
+          -train_json $ATOM_DATASETS/rrbot/train/atom_calibration.json \
+          -test_json $ATOM_DATASETS/rrbot/train/dataset.json \
+          -ss rgb_left -st rgb_right \
+          -csf 'lambda x: int(x) in [1, 2]' \
+          -sfr -sfrn /tmp/rgb_rgb_evaluation.csv
+        files_to_collect:
+          - '$ATOM_DATASETS/rrbot/train/atom_calibration.json'
+          - '$ATOM_DATASETS/rrbot/train/atom_calibration_params.yml'
+          - '$ATOM_DATASETS/rrbot/train/command_line_args.yml'
+          - '/tmp/rgb_rgb_evaluation.csv'
+      nig_0.1_run001_fold002:
+        cmd: |
+          rosrun atom_calibration calibrate -json $ATOM_DATASETS/rrbot/train/dataset.json \
+          -v -max_nfev 2 -ss 1 \
+          -nig 0.1 0.1 \
+          -csf 'lambda x: int(x) in [1, 2, 3]' \
+          && \
+          rosrun atom_evaluation rgb_to_rgb_evaluation \
+          -train_json $ATOM_DATASETS/rrbot/train/atom_calibration.json \
+          -test_json $ATOM_DATASETS/rrbot/train/dataset.json \
+          -ss rgb_left -st rgb_right \
+          -csf 'lambda x: int(x) in [0]' \
+          -sfr -sfrn /tmp/rgb_rgb_evaluation.csv
+        files_to_collect:
+          - '$ATOM_DATASETS/rrbot/train/atom_calibration.json'
+          - '$ATOM_DATASETS/rrbot/train/atom_calibration_params.yml'
+          - '$ATOM_DATASETS/rrbot/train/command_line_args.yml'
+          - '/tmp/rgb_rgb_evaluation.csv'
+      nig_0.1_run001_fold003:
+        cmd: |
+          rosrun atom_calibration calibrate -json $ATOM_DATASETS/rrbot/train/dataset.json \
+          -v -max_nfev 2 -ss 1 \
+          -nig 0.1 0.1 \
+          -csf 'lambda x: int(x) in [0, 1, 2]' \
+          && \
+          rosrun atom_evaluation rgb_to_rgb_evaluation \
+          -train_json $ATOM_DATASETS/rrbot/train/atom_calibration.json \
+          -test_json $ATOM_DATASETS/rrbot/train/dataset.json \
+          -ss rgb_left -st rgb_right \
+          -csf 'lambda x: int(x) in [3]' \
+          -sfr -sfrn /tmp/rgb_rgb_evaluation.csv
+        files_to_collect:
+          - '$ATOM_DATASETS/rrbot/train/atom_calibration.json'
+          - '$ATOM_DATASETS/rrbot/train/atom_calibration_params.yml'
+          - '$ATOM_DATASETS/rrbot/train/command_line_args.yml'
+          - '/tmp/rgb_rgb_evaluation.csv'
+    
+    
+      nig_0.1_run002_fold001:
+        cmd: |
+          rosrun atom_calibration calibrate -json $ATOM_DATASETS/rrbot/train/dataset.json \
+          -v -max_nfev 2 -ss 2 \
+          -nig 0.1 0.1 \
+          -csf 'lambda x: int(x) in [0, 3]' \
+          && \
+          rosrun atom_evaluation rgb_to_rgb_evaluation \
+          -train_json $ATOM_DATASETS/rrbot/train/atom_calibration.json \
+          -test_json $ATOM_DATASETS/rrbot/train/dataset.json \
+          -ss rgb_left -st rgb_right \
+          -csf 'lambda x: int(x) in [1, 2]' \
+          -sfr -sfrn /tmp/rgb_rgb_evaluation.csv
+        files_to_collect:
+          - '$ATOM_DATASETS/rrbot/train/atom_calibration.json'
+          - '$ATOM_DATASETS/rrbot/train/atom_calibration_params.yml'
+          - '$ATOM_DATASETS/rrbot/train/command_line_args.yml'
+          - '/tmp/rgb_rgb_evaluation.csv'
+      nig_0.1_run002_fold002:
+        cmd: |
+          rosrun atom_calibration calibrate -json $ATOM_DATASETS/rrbot/train/dataset.json \
+          -v -max_nfev 2 -ss 2 \
+          -nig 0.1 0.1 \
+          -csf 'lambda x: int(x) in [1, 2, 3]' \
+          && \
+          rosrun atom_evaluation rgb_to_rgb_evaluation \
+          -train_json $ATOM_DATASETS/rrbot/train/atom_calibration.json \
+          -test_json $ATOM_DATASETS/rrbot/train/dataset.json \
+          -ss rgb_left -st rgb_right \
+          -csf 'lambda x: int(x) in [0]' \
+          -sfr -sfrn /tmp/rgb_rgb_evaluation.csv
+        files_to_collect:
+          - '$ATOM_DATASETS/rrbot/train/atom_calibration.json'
+          - '$ATOM_DATASETS/rrbot/train/atom_calibration_params.yml'
+          - '$ATOM_DATASETS/rrbot/train/command_line_args.yml'
+          - '/tmp/rgb_rgb_evaluation.csv'
+      nig_0.1_run002_fold003:
+        cmd: |
+          rosrun atom_calibration calibrate -json $ATOM_DATASETS/rrbot/train/dataset.json \
+          -v -max_nfev 2 -ss 2 \
+          -nig 0.1 0.1 \
+          -csf 'lambda x: int(x) in [0, 1, 2]' \
+          && \
+          rosrun atom_evaluation rgb_to_rgb_evaluation \
+          -train_json $ATOM_DATASETS/rrbot/train/atom_calibration.json \
+          -test_json $ATOM_DATASETS/rrbot/train/dataset.json \
+          -ss rgb_left -st rgb_right \
+          -csf 'lambda x: int(x) in [3]' \
+          -sfr -sfrn /tmp/rgb_rgb_evaluation.csv
+        files_to_collect:
+          - '$ATOM_DATASETS/rrbot/train/atom_calibration.json'
+          - '$ATOM_DATASETS/rrbot/train/atom_calibration_params.yml'
+          - '$ATOM_DATASETS/rrbot/train/command_line_args.yml'
+          - '/tmp/rgb_rgb_evaluation.csv'
+  
+    
+    
+      nig_0.2_run001_fold001:
+        cmd: |
+          rosrun atom_calibration calibrate -json $ATOM_DATASETS/rrbot/train/dataset.json \
+          -v -max_nfev 2 -ss 1 \
+          -nig 0.2 0.2 \
+          -csf 'lambda x: int(x) in [0, 3]' \
+          && \
+          rosrun atom_evaluation rgb_to_rgb_evaluation \
+          -train_json $ATOM_DATASETS/rrbot/train/atom_calibration.json \
+          -test_json $ATOM_DATASETS/rrbot/train/dataset.json \
+          -ss rgb_left -st rgb_right \
+          -csf 'lambda x: int(x) in [1, 2]' \
+          -sfr -sfrn /tmp/rgb_rgb_evaluation.csv
+        files_to_collect:
+          - '$ATOM_DATASETS/rrbot/train/atom_calibration.json'
+          - '$ATOM_DATASETS/rrbot/train/atom_calibration_params.yml'
+          - '$ATOM_DATASETS/rrbot/train/command_line_args.yml'
+          - '/tmp/rgb_rgb_evaluation.csv'
+      nig_0.2_run001_fold002:
+        cmd: |
+          rosrun atom_calibration calibrate -json $ATOM_DATASETS/rrbot/train/dataset.json \
+          -v -max_nfev 2 -ss 1 \
+          -nig 0.2 0.2 \
+          -csf 'lambda x: int(x) in [1, 2, 3]' \
+          && \
+          rosrun atom_evaluation rgb_to_rgb_evaluation \
+          -train_json $ATOM_DATASETS/rrbot/train/atom_calibration.json \
+          -test_json $ATOM_DATASETS/rrbot/train/dataset.json \
+          -ss rgb_left -st rgb_right \
+          -csf 'lambda x: int(x) in [0]' \
+          -sfr -sfrn /tmp/rgb_rgb_evaluation.csv
+        files_to_collect:
+          - '$ATOM_DATASETS/rrbot/train/atom_calibration.json'
+          - '$ATOM_DATASETS/rrbot/train/atom_calibration_params.yml'
+          - '$ATOM_DATASETS/rrbot/train/command_line_args.yml'
+          - '/tmp/rgb_rgb_evaluation.csv'
+      nig_0.2_run001_fold003:
+        cmd: |
+          rosrun atom_calibration calibrate -json $ATOM_DATASETS/rrbot/train/dataset.json \
+          -v -max_nfev 2 -ss 1 \
+          -nig 0.2 0.2 \
+          -csf 'lambda x: int(x) in [0, 1, 2]' \
+          && \
+          rosrun atom_evaluation rgb_to_rgb_evaluation \
+          -train_json $ATOM_DATASETS/rrbot/train/atom_calibration.json \
+          -test_json $ATOM_DATASETS/rrbot/train/dataset.json \
+          -ss rgb_left -st rgb_right \
+          -csf 'lambda x: int(x) in [3]' \
+          -sfr -sfrn /tmp/rgb_rgb_evaluation.csv
+        files_to_collect:
+          - '$ATOM_DATASETS/rrbot/train/atom_calibration.json'
+          - '$ATOM_DATASETS/rrbot/train/atom_calibration_params.yml'
+          - '$ATOM_DATASETS/rrbot/train/command_line_args.yml'
+          - '/tmp/rgb_rgb_evaluation.csv'
+    
+    
+      nig_0.2_run002_fold001:
+        cmd: |
+          rosrun atom_calibration calibrate -json $ATOM_DATASETS/rrbot/train/dataset.json \
+          -v -max_nfev 2 -ss 2 \
+          -nig 0.2 0.2 \
+          -csf 'lambda x: int(x) in [0, 3]' \
+          && \
+          rosrun atom_evaluation rgb_to_rgb_evaluation \
+          -train_json $ATOM_DATASETS/rrbot/train/atom_calibration.json \
+          -test_json $ATOM_DATASETS/rrbot/train/dataset.json \
+          -ss rgb_left -st rgb_right \
+          -csf 'lambda x: int(x) in [1, 2]' \
+          -sfr -sfrn /tmp/rgb_rgb_evaluation.csv
+        files_to_collect:
+          - '$ATOM_DATASETS/rrbot/train/atom_calibration.json'
+          - '$ATOM_DATASETS/rrbot/train/atom_calibration_params.yml'
+          - '$ATOM_DATASETS/rrbot/train/command_line_args.yml'
+          - '/tmp/rgb_rgb_evaluation.csv'
+      nig_0.2_run002_fold002:
+        cmd: |
+          rosrun atom_calibration calibrate -json $ATOM_DATASETS/rrbot/train/dataset.json \
+          -v -max_nfev 2 -ss 2 \
+          -nig 0.2 0.2 \
+          -csf 'lambda x: int(x) in [1, 2, 3]' \
+          && \
+          rosrun atom_evaluation rgb_to_rgb_evaluation \
+          -train_json $ATOM_DATASETS/rrbot/train/atom_calibration.json \
+          -test_json $ATOM_DATASETS/rrbot/train/dataset.json \
+          -ss rgb_left -st rgb_right \
+          -csf 'lambda x: int(x) in [0]' \
+          -sfr -sfrn /tmp/rgb_rgb_evaluation.csv
+        files_to_collect:
+          - '$ATOM_DATASETS/rrbot/train/atom_calibration.json'
+          - '$ATOM_DATASETS/rrbot/train/atom_calibration_params.yml'
+          - '$ATOM_DATASETS/rrbot/train/command_line_args.yml'
+          - '/tmp/rgb_rgb_evaluation.csv'
+      nig_0.2_run002_fold003:
+        cmd: |
+          rosrun atom_calibration calibrate -json $ATOM_DATASETS/rrbot/train/dataset.json \
+          -v -max_nfev 2 -ss 2 \
+          -nig 0.2 0.2 \
+          -csf 'lambda x: int(x) in [0, 1, 2]' \
+          && \
+          rosrun atom_evaluation rgb_to_rgb_evaluation \
+          -train_json $ATOM_DATASETS/rrbot/train/atom_calibration.json \
+          -test_json $ATOM_DATASETS/rrbot/train/dataset.json \
+          -ss rgb_left -st rgb_right \
+          -csf 'lambda x: int(x) in [3]' \
+          -sfr -sfrn /tmp/rgb_rgb_evaluation.csv
+        files_to_collect:
+          - '$ATOM_DATASETS/rrbot/train/atom_calibration.json'
+          - '$ATOM_DATASETS/rrbot/train/atom_calibration_params.yml'
+          - '$ATOM_DATASETS/rrbot/train/command_line_args.yml'
+          - '/tmp/rgb_rgb_evaluation.csv'
+# End the loop

--- a/atom_batch_execution/experiments/rrbot_example/data.yml
+++ b/atom_batch_execution/experiments/rrbot_example/data.yml
@@ -1,0 +1,33 @@
+#
+#           █████╗ ████████╗ ██████╗ ███╗   ███╗
+#          ██╔══██╗╚══██╔══╝██╔═══██╗████╗ ████║
+#          ███████║   ██║   ██║   ██║██╔████╔██║
+#          ██╔══██║   ██║   ██║   ██║██║╚██╔╝██║
+#   __     ██║  ██║   ██║   ╚██████╔╝██║ ╚═╝ ██║    _
+#  / _|    ╚═╝  ╚═╝   ╚═╝    ╚═════╝ ╚═╝     ╚═╝   | |
+#  | |_ _ __ __ _ _ __ ___   _____      _____  _ __| | __
+#  |  _| '__/ _` | '_ ` _ \ / _ \ \ /\ / / _ \| '__| |/ /
+#  | | | | | (_| | | | | | |  __/\ v  v / (_) | |  |   <
+#  |_| |_|  \__,_|_| |_| |_|\___| \_/\_/ \___/|_|  |_|\_\
+#  https://github.com/lardemua/atom
+
+# this yml file contains variables to be used in conjunction with batch.yml
+
+# Auxiliary variables, to be used to render other fields in the template.yml.j2 file
+package_path: "package://rrbot_calibration"
+dataset_path: '$ATOM_DATASETS/rrbot/train'
+
+# Runs are repetitions of the experiments for gathering statistically significant results
+runs: [1,2]
+
+cross_validation:
+  type: "stratified-k-fold" 
+  n_splits: 3 # Number of folds
+  train_size: # Percentage of the dataset used for training, only used in StratifiedShuffleSplit
+
+# Experiments are executions with a set of input parameters
+experiments:
+
+  # One pattern
+  - {name: nig_0.1, nig_value: 0.1}
+  - {name: nig_0.2, nig_value: 0.2}

--- a/atom_batch_execution/experiments/rrbot_example/old_template.yml.j2
+++ b/atom_batch_execution/experiments/rrbot_example/old_template.yml.j2
@@ -1,0 +1,44 @@
+#
+#           █████╗ ████████╗ ██████╗ ███╗   ███╗
+#          ██╔══██╗╚══██╔══╝██╔═══██╗████╗ ████║
+#          ███████║   ██║   ██║   ██║██╔████╔██║
+#          ██╔══██║   ██║   ██║   ██║██║╚██╔╝██║
+#   __     ██║  ██║   ██║   ╚██████╔╝██║ ╚═╝ ██║    _
+#  / _|    ╚═╝  ╚═╝   ╚═╝    ╚═════╝ ╚═╝     ╚═╝   | |
+#  | |_ _ __ __ _ _ __ ___   _____      _____  _ __| | __
+#  |  _| '__/ _` | '_ ` _ \ / _ \ \ /\ / / _ \| '__| |/ /
+#  | | | | | (_| | | | | | |  __/\ v  v / (_) | |  |   <
+#  |_| |_|  \__,_|_| |_| |_|\___| \_/\_/ \___/|_|  |_|\_\
+#  https://github.com/lardemua/atom
+
+# this yml file contains a set of commands to be run in batch.
+# use jinja2 syntax for referencing variables
+
+# Preprocessing will run only once before all experiments.
+preprocessing:
+  cmd: |
+    ls /tmp
+
+# Define batches to run
+experiments:
+{%- for e in experiments %}
+  {% for run in runs %}
+    {{ e.name }}_run{{ '%03d' % loop.index }}:
+      cmd: |
+        rosrun atom_calibration calibrate -json {{ dataset_path }}/dataset.json \
+        -v -max_nfev 2 -ss {{ run }} \
+        -nig {{ e.nig_value }} {{ e.nig_value }} \
+        && \
+        rosrun atom_evaluation rgb_to_rgb_evaluation \
+        -train_json {{ dataset_path }}/atom_calibration.json \
+        -test_json {{ dataset_path }}/dataset.json \
+        -ss rgb_left -st rgb_right \
+        -sfr -sfrn /tmp/rgb_rgb_evaluation.csv
+      files_to_collect:
+        - '{{ dataset_path }}/atom_calibration.json'
+        - '{{ dataset_path }}/atom_calibration_params.yml'
+        - '{{ dataset_path }}/command_line_args.yml'
+        - '/tmp/rgb_rgb_evaluation.csv'
+  {%- endfor %}
+{%- endfor %}
+# End the loop

--- a/atom_batch_execution/experiments/rrbot_example/template.yml.j2
+++ b/atom_batch_execution/experiments/rrbot_example/template.yml.j2
@@ -1,0 +1,49 @@
+#
+#           █████╗ ████████╗ ██████╗ ███╗   ███╗
+#          ██╔══██╗╚══██╔══╝██╔═══██╗████╗ ████║
+#          ███████║   ██║   ██║   ██║██╔████╔██║
+#          ██╔══██║   ██║   ██║   ██║██║╚██╔╝██║
+#   __     ██║  ██║   ██║   ╚██████╔╝██║ ╚═╝ ██║    _
+#  / _|    ╚═╝  ╚═╝   ╚═╝    ╚═════╝ ╚═╝     ╚═╝   | |
+#  | |_ _ __ __ _ _ __ ___   _____      _____  _ __| | __
+#  |  _| '__/ _` | '_ ` _ \ / _ \ \ /\ / / _ \| '__| |/ /
+#  | | | | | (_| | | | | | |  __/\ v  v / (_) | |  |   <
+#  |_| |_|  \__,_|_| |_| |_|\___| \_/\_/ \___/|_|  |_|\_\
+#  https://github.com/lardemua/atom
+
+# this yml file contains a set of commands to be run in batch.
+# use jinja2 syntax for referencing variables
+
+# Preprocessing will run only once before all experiments.
+preprocessing:
+  cmd: |
+    ls /tmp
+
+# Define batches to run
+experiments:
+{%- for e in experiments %}
+  {% for run in runs %}
+    {% set run_index = loop.index %}
+    {% for fold in folds %}
+      {{ e.name }}_run{{ '%03d' % run_index }}_fold{{ '%03d' % loop.index }}:
+        cmd: |
+          rosrun atom_calibration calibrate -json {{ dataset_path }}/dataset.json \
+          -v -max_nfev 2 -ss {{ run }} \
+          -nig {{ e.nig_value }} {{ e.nig_value }} \
+          -csf 'lambda x: int(x) in {{ fold[0] }}' \
+          && \
+          rosrun atom_evaluation rgb_to_rgb_evaluation \
+          -train_json {{ dataset_path }}/atom_calibration.json \
+          -test_json {{ dataset_path }}/dataset.json \
+          -ss rgb_left -st rgb_right \
+          -csf 'lambda x: int(x) in {{ fold[1] }}' \
+          -sfr -sfrn /tmp/rgb_rgb_evaluation.csv
+        files_to_collect:
+          - '{{ dataset_path }}/atom_calibration.json'
+          - '{{ dataset_path }}/atom_calibration_params.yml'
+          - '{{ dataset_path }}/command_line_args.yml'
+          - '/tmp/rgb_rgb_evaluation.csv'
+    {%- endfor %}
+  {%- endfor %}
+{%- endfor %}
+# End the loop

--- a/atom_batch_execution/scripts/batch_execution
+++ b/atom_batch_execution/scripts/batch_execution
@@ -81,7 +81,10 @@ def main():
 
     # Generate classes and collection keys
     classes, collection_keys = generateClasses(dataset)
-    print(classes)
+
+    # Safeguard to guarantee backwards compatibility
+    if 'cross_validation' not in data:
+        data['cross_validation'] = {'type': None, 'n_splits': None}
 
     # Process cross validation data
     if data['cross_validation']['type'] == 'stratified-k-fold':
@@ -109,8 +112,9 @@ def main():
         folds = cross_validator.split(collection_keys, classes)
 
     else:
-        # Print an error message if the cross validation type is not supported
-        atomError(f'Cross validation type {data["cross_validation_type"]} not supported')
+        # Print error message if the cross validation type is not supported
+        folds  = [(collection_keys, collection_keys)]
+        bprint('Running without any cross validation.')
 
     # Dataset is no longer needed
     del dataset

--- a/atom_batch_execution/scripts/batch_execution
+++ b/atom_batch_execution/scripts/batch_execution
@@ -11,11 +11,13 @@ import yaml
 import jinja2
 from jinja2 import Template, Undefined
 from jinja2 import Environment, FileSystemLoader
+from sklearn.model_selection import StratifiedKFold, KFold, LeaveOneOut, StratifiedShuffleSplit
 
 from colorama import Fore, Back, Style
 from pytictoc import TicToc
 
 from atom_core.config_io import atomError, uriReader
+from atom_core.dataset_io import loadJSONFile
 from atom_core.system import resolvePath
 from atom_core.utilities import atomWarn, removeColorsFromText
 
@@ -23,6 +25,33 @@ from atom_core.utilities import atomWarn, removeColorsFromText
 def bprint(text):
     """bprint (batch print) will always print in blue color with yellow background """
     print(Fore.BLUE + Back.YELLOW + text + Style.RESET_ALL)
+
+
+def generateClasses(dataset):
+    """
+    Generate classes based on an ATOM dataset.
+    Classes follow the format detected_pattern--detected_sensor1-detected_sensor2-[...]---[...]
+
+    Args:
+        dataset (dict): ATOM dataset.
+
+    Returns:
+        tuple: A tuple containing the classes and collection keys.
+
+    """
+    classes = []
+    collection_keys = list(dataset['collections'].keys())
+    for collection_key in collection_keys:
+        detected_sensors = []
+        class_name = ''
+        for pattern_key in dataset['patterns'].keys():
+            for sensor_key in dataset['sensors'].keys():
+                if dataset['collections'][collection_key]['labels'][pattern_key][sensor_key]['detected']:
+                    detected_sensors.append(sensor_key)
+            detected_pattern_and_sensors = pattern_key + '--' + '-'.join(detected_sensors)
+            class_name += detected_pattern_and_sensors + '---'
+        classes.append(class_name.rstrip('---'))
+    return classes, collection_keys
 
 
 def main():
@@ -46,6 +75,51 @@ def main():
     with open(args['data_filename']) as f:
         file_content = f.read()
         data = yaml.safe_load(file_content)
+
+    # Load dataset
+    dataset = loadJSONFile(data['dataset_path'] + '/dataset.json')
+
+    # Generate classes and collection keys
+    classes, collection_keys = generateClasses(dataset)
+    print(classes)
+
+    # Process cross validation data
+    if data['cross_validation']['type'] == 'stratified-k-fold':
+        # Use StratifiedKFold for cross validation
+        cross_validator = StratifiedKFold(n_splits=data['cross_validation']['n_splits'], shuffle=True)
+        # Split the data into folds
+        folds = cross_validator.split(collection_keys, classes)
+
+    elif data['cross_validation']['type'] == 'k-fold':
+        # Use KFold for cross validation
+        cross_validator = KFold(n_splits=data['cross_validation']['n_splits'], shuffle=True)
+        # Split the data into folds
+        folds = cross_validator.split(collection_keys)
+
+    elif data['cross_validation']['type'] == 'leave-one-out':
+        # Use LeaveOneOut for cross validation
+        cross_validator = LeaveOneOut()
+        # Split the data into folds
+        folds = cross_validator.split(collection_keys)    
+
+    elif data['cross_validation']['type'] == 'stratified-shuffle-split' and data['cross_validation']['train_size']:
+        # Use StratifiedShuffleSplit for cross validation
+        cross_validator = StratifiedShuffleSplit(n_splits=data['cross_validation']['n_splits'], train_size=data['cross_validation']['train_size']) 
+        # Split the data into folds
+        folds = cross_validator.split(collection_keys, classes)
+
+    else:
+        # Print an error message if the cross validation type is not supported
+        atomError(f'Cross validation type {data["cross_validation_type"]} not supported')
+
+    # Dataset is no longer needed
+    del dataset
+
+    # Generate a list of folds
+    fold_list = [[list(train), list(test)] for (train, test) in folds]
+
+    # Add folds to data
+    data['folds'] = fold_list
 
     # Template engine1 setup
     file_loader = FileSystemLoader(os.path.dirname(args['template_filename']))
@@ -99,9 +173,9 @@ def main():
     # Run experiments
     num_experiments = len(config['experiments'].keys())
     for idx, (experiment_key, experiment) in enumerate(config['experiments'].items()):
-        print('\n')
         bprint(Style.BRIGHT + 'Experiment ' + str(idx) + ' of ' + str(num_experiments-1) + ': ' + experiment_key)
         bprint('Executing command:\n' + experiment['cmd'])
+
 
         if args['dry_run']:
             bprint('Running in dry run mode...')

--- a/atom_batch_execution/scripts/process_results
+++ b/atom_batch_execution/scripts/process_results
@@ -76,7 +76,11 @@ def main():
     folders = [x for x in files_and_folders if os.path.isdir(args['results_folder'] + '/' + x)]
     fold_suffix_size = len(args['fold_suffix']) + 3  # because the suffix is complemented by the run number as in 001
     run_suffix_size = len(args['run_suffix']) + 3  # because the suffix is complemented by the run number as in 001
-    suffix_size = fold_suffix_size + run_suffix_size
+    suffix_size = 0
+    if args['fold_suffix'] in folders[0]:
+        suffix_size += fold_suffix_size
+    if args['run_suffix'] in folders[0]:
+        suffix_size += run_suffix_size
     experiments = list(set([x[:-suffix_size] for x in folders]))  # Remove the "_foldXX" suffix
 
     # files_to_process = ['comparison_to_ground_truth_transforms.csv', 'comparison_to_ground_truth_joints.csv']
@@ -107,6 +111,8 @@ def main():
             filenames = [run + '/' + file_to_process for run in files_and_folders]
 
             average_df = averageCsvFiles(filenames)
+
+            average_df = average_df.drop(columns=['Collection #'])
 
             output_file = args['output_folder'] + '/' + experiment + '/' + file_to_process
             print('Saving average to ' + Fore.BLUE + output_file + Style.RESET_ALL)

--- a/atom_batch_execution/scripts/process_results
+++ b/atom_batch_execution/scripts/process_results
@@ -55,6 +55,8 @@ def main():
                     required=True, type=str)
     ap.add_argument("-rs", "--run_suffix", help="Suffix used to signal multiple runs of the same experiment.",
                     required=False, default='_run', type=str)
+    ap.add_argument("-fs", "--fold_suffix", help="Suffix used to signal multiple folds of the same run.",
+                    required=False, default='_fold', type=str)
 
     args = vars(ap.parse_args())
 
@@ -72,8 +74,10 @@ def main():
     # Create a list of experiments
     files_and_folders = os.listdir(args['results_folder'])
     folders = [x for x in files_and_folders if os.path.isdir(args['results_folder'] + '/' + x)]
-    suffix_size = len(args['run_suffix']) + 3  # because the suffix is complemented by the run number as in 001
-    experiments = list(set([x[:-suffix_size] for x in folders]))  # Remove the "_runXX" suffix
+    fold_suffix_size = len(args['fold_suffix']) + 3  # because the suffix is complemented by the run number as in 001
+    run_suffix_size = len(args['run_suffix']) + 3  # because the suffix is complemented by the run number as in 001
+    suffix_size = fold_suffix_size + run_suffix_size
+    experiments = list(set([x[:-suffix_size] for x in folders]))  # Remove the "_foldXX" suffix
 
     # files_to_process = ['comparison_to_ground_truth_transforms.csv', 'comparison_to_ground_truth_joints.csv']
     # files_to_process = ['single_rgb_evaluation.csv']


### PR DESCRIPTION
As stated in #899, this PR adds cross validation to ATOM.
It currently supports StratifiedKFold, KFold, LeaveOneOut, and StratifiedShuffleSplit from scikit-learn.
Older experiments without cross validation should also be compatible.
This has been tested by me and @Kazadhum.
If you need more info, please read #899.