### PR TITLE
Single tf noise

### DIFF
--- a/atom_calibration/scripts/calibrate
+++ b/atom_calibration/scripts/calibrate
@@ -26,7 +26,9 @@ from atom_calibration.calibration.getters_and_setters import (
 from atom_calibration.calibration.objective_function import errorReport, objectiveFunction, replaceTransformsFromJoints
 from atom_calibration.calibration.visualization import setupVisualization, visualizationFunction
 from atom_core.dataset_io import (addNoiseToInitialGuess,
-                                  addNoiseToJointParameters,
+                                  addBiasToJointParameters,
+                                  addNoiseToTF,
+                                  addNoiseFromNoisyTFLinks,
                                   checkIfAtLeastOneLabeledCollectionPerSensor,
                                   filterCollectionsFromDataset,
                                   filterSensorsFromDataset,
@@ -44,6 +46,7 @@ from atom_core.utilities import (atomError, createLambdaExpressionsForArgs,
                                  printComparisonToGroundTruth, saveCommandLineArgsYml)
 from atom_core.xacro_io import saveResultsXacro
 from atom_core.results_yml_io import saveResultsYml
+from atom_core.config_io import parse_list_of_transformations, mutually_inclusive_conditions
 
 
 # -------------------------------------------------------------------------------
@@ -126,6 +129,13 @@ def main():
         type=str, required=False)
     ap.add_argument("-jbv", "--joint_bias_values", nargs='+',
                     help='Operates in tandem with "joint_bias_names"', type=float, required=False)
+    
+    ap.add_argument("-ntfl", "--noisy_tf_links", type=parse_list_of_transformations, help='''Pairs of links defining the transformations to which noise will be added, in the format linkParent1:linkChild2,linkParentA:linkChildB (links defining a transformation separated by
+                    : and different pairs separeted by ,)
+                    Note : This flag overrides the -nig flag''')
+    ap.add_argument("-ntfv", "--noisy_tf_values", nargs=2, type=float, metavar=("translation", "rotation"),
+                    help="Translation(m) and Rotation(rad)(respectively) noise values to add to the transformations specified by-ntfl")
+
     ap.add_argument(
         "-ssf", "--sensor_selection_function", default=None, type=str,
         help="A string to be evaluated into a lambda function that receives a sensor name as input and "
@@ -205,6 +215,9 @@ def main():
     args['dataset_folder'] = os.path.dirname(args['json_file'])
     output_folder = os.path.dirname(args['json_file'])
 
+    # -sce wasn't working because args previously had this key
+    args['output_folder'] = output_folder
+
     # ---------------------------------------
     # --- Read data from file
     # ---------------------------------------
@@ -261,8 +274,10 @@ def main():
 
     addNoiseToInitialGuess(dataset, args, selected_collection_key)
 
+    addNoiseFromNoisyTFLinks(dataset,args,selected_collection_key)
+
     # Must add noise, transfer new joints to transforms, and only after remove unselected joints
-    addNoiseToJointParameters(dataset, args)
+    addBiasToJointParameters(dataset, args)
     replaceTransformsFromJoints(dataset)
     dataset = filterJointsFromDataset(dataset, args)
     dataset = filterJointParametersFromDataset(dataset, args)

--- a/atom_core/src/atom_core/config_io.py
+++ b/atom_core/src/atom_core/config_io.py
@@ -16,6 +16,25 @@ from colorama import Fore, Style
 from atom_core.utilities import atomError
 from atom_core.system import resolvePath, expandToLaunchEnv
 
+def mutually_inclusive_conditions(A,B):
+
+    if A is not None and B is not None:
+        return True
+    elif A is None and B is None:
+        return False
+    else:
+        atomError(f'{Fore.RED}-ntfl{Style.RESET_ALL} and {Fore.RED}-ntfv{Style.RESET_ALL} flags are mutually inclusive') 
+        exit()
+
+def parse_list_of_transformations(s):
+    list_of_transformations = []
+    for pair in s.split(','):
+        elements = pair.split(':')
+        if len(elements) != 2:
+            raise atomError("Each pair of transformations parsed must contain exactly 2 elements separated by ':'")
+        list_of_transformations.append(elements)
+    return list_of_transformations
+
 
 def dictionaries_have_same_keys(d1, d2):
 

--- a/atom_core/src/atom_core/dataset_io.py
+++ b/atom_core/src/atom_core/dataset_io.py
@@ -24,8 +24,8 @@ from cv_bridge import CvBridge
 from colorama import Fore, Style
 from rospy_message_converter import message_converter
 from std_msgs.msg import Header
-from atom_core.config_io import uriReader
-from atom_core.naming import generateName, generateKey
+from atom_core.config_io import uriReader, mutually_inclusive_conditions
+from atom_core.naming import generateName, generateKey, generateCollectionKey
 from atom_calibration.collect.label_messages import (
     convertDepthImage32FC1to16UC1, convertDepthImage16UC1to32FC1, numpyFromPointCloudMsg)
 
@@ -787,7 +787,7 @@ def filterAdditionalTfsFromDataset(dataset, args):
     return dataset
 
 
-def addNoiseToJointParameters(dataset, args):
+def addBiasToJointParameters(dataset, args):
     """
     Adds noise
     :param dataset:
@@ -828,6 +828,25 @@ def addNoiseToJointParameters(dataset, args):
             collection['joints'][joint_name][joint_param] = collection['joints'][joint_name][
                 joint_param] + joint_bias
 
+def addNoiseFromNoisyTFLinks(dataset,args,selected_collection_key):
+
+    # Verify both arguments were provided
+    # Unfortunately, mutually inclusive arguments are not built into argparse
+    # https://github.com/python/cpython/issues/55797
+
+    if not mutually_inclusive_conditions(args['noisy_tf_links'], args['noisy_tf_values']):
+        return
+
+
+    # Iterate through pairs of tf's and apply noise
+    translation_tf_noise = args['noisy_tf_values'][0]
+    rotation_tf_noise = args['noisy_tf_values'][1]
+
+    for tf_pair in args['noisy_tf_links']:
+        
+        calibration_parent,calibration_child = tf_pair[0],tf_pair[1]
+        addNoiseToTF(dataset,selected_collection_key,calibration_parent,calibration_child,translation_tf_noise,rotation_tf_noise)
+
 
 def addNoiseToInitialGuess(dataset, args, selected_collection_key):
     """
@@ -836,19 +855,38 @@ def addNoiseToInitialGuess(dataset, args, selected_collection_key):
     :param args: Makes use of nig, i.e., the amount of noise to add to the initial guess atomic transformations to be
                  calibrated
     """
+    # TODO create a issue to discuss if its ok to skip this function call when the noise is 0
+    # if args['noisy_initial_guess'] == [0,0]:
+    #     print("No noise added to transform's initial guess")
+    #     return
+
     if args['sample_seed'] is not None:
         np.random.seed(args['sample_seed'])
 
     nig_trans = args['noisy_initial_guess'][0]
     nig_rot = args['noisy_initial_guess'][1]
 
+
+    # Checking if tf to add noise is also defined in -ntfl, in which case the noise shouldn't be added here
+    # Determining membership in sets is much faster than lists
+    ntfl_tfs = set()
+    if args['noisy_tf_links']:
+        for tf_pair in args['noisy_tf_links']:
+            ntfl_tfs.add(generateKey(tf_pair[0],tf_pair[1]))
+
     # add noise to additional tfs for simulation
     if dataset['calibration_config']['additional_tfs'] is not None:
         for _, additional_tf in dataset['calibration_config']['additional_tfs'].items():
+
             calibration_child = additional_tf['child_link']
             calibration_parent = additional_tf['parent_link']
-            addNoiseToTF(dataset, selected_collection_key, calibration_parent,
-                         calibration_child, nig_trans, nig_rot)
+
+            tf_to_add_noise = generateKey(calibration_parent,calibration_child)
+            if tf_to_add_noise in ntfl_tfs:
+                atomWarn(f'Not adding initial guess noise to {tf_to_add_noise} because its defined in -ntfl')
+                continue
+
+            addNoiseToTF(dataset, selected_collection_key, calibration_parent, calibration_child, nig_trans, nig_rot)
 
     # add noise to sensors tfs for simulation
     for sensor_key, sensor in dataset['sensors'].items():
@@ -858,13 +896,45 @@ def addNoiseToInitialGuess(dataset, args, selected_collection_key):
         if sensor_key != dataset['calibration_config']['anchored_sensor']:
             calibration_child = sensor['calibration_child']
             calibration_parent = sensor['calibration_parent']
-            addNoiseToTF(dataset, selected_collection_key, calibration_parent,
-                         calibration_child, nig_trans, nig_rot)
+
+            tf_to_add_noise = generateKey(calibration_parent,calibration_child)
+            if tf_to_add_noise in ntfl_tfs:
+                atomWarn(f'Not adding initial guess noise to {tf_to_add_noise} because its defined in -ntfl')
+                continue
+
+            addNoiseToTF(dataset, selected_collection_key, calibration_parent, calibration_child, nig_trans, nig_rot)
+
+# TODO make a basic function called by fixed and multiple
+
+def computeNoise(initial_translation,initial_euler_angles,translation_noise_magnitude,rotation_noise_magnitude):
+    '''
+    Computes both the translation and rotation noise given a certain magnitude and returns the new noisy translation/rotation vectors
+    '''
+    # Translation
+
+    v = np.random.uniform(-1.0, 1.0, 3)
+    v = v / np.linalg.norm(v)
+    translation_delta = v * translation_noise_magnitude
+
+    new_translation = initial_translation + translation_delta
+    # Rotation
+
+    # Its necessary to redefine 'v' to ensure that the translation and rotation noise aren't always the same given the same magnitude
+    v = np.random.uniform(-1.0, 1.0, 3)
+    v = v / np.linalg.norm(v)
+    rotation_delta = v * rotation_noise_magnitude
+
+    new_euler_angles = initial_euler_angles + rotation_delta
+
+    return new_translation,new_euler_angles
 
 
-def addNoiseToTF(dataset, selected_collection_key, calibration_parent, calibration_child, nig_trans, nig_rot):
+def addNoiseToTF(dataset, selected_collection_key, calibration_parent, calibration_child, noise_trans, noise_rot):
 
+    print(Fore.RED + 'Transformation parent ' + calibration_parent + ' child ' + calibration_child + Style.RESET_ALL)
     transform_key = generateKey(calibration_parent, calibration_child, suffix='')
+
+    atomWarn(f'Adding noise bigger than 1.0m/rad right now is bugged and might yield unexpected results. Check issue #929 for more information')
 
     # because of #900, and for retrocompatibility with old datasets, we will assume that if the transforms field does
     # not exist in the dataset, then the transformation is fixed
@@ -872,24 +942,17 @@ def addNoiseToTF(dataset, selected_collection_key, calibration_parent, calibrati
 
         # Get original transformation
         quat = dataset['collections'][selected_collection_key]['transforms'][transform_key]['quat']
-        translation = dataset['collections'][selected_collection_key]['transforms'][
-            transform_key]['trans']
+        translation = dataset['collections'][selected_collection_key]['transforms'][transform_key]['trans']
 
-        # Add noise to the 6 pose parameters
-        v = np.random.uniform(-1.0, 1.0, 3)
-        v = v / np.linalg.norm(v)
-        new_translation = translation + v * nig_trans
-
-        v = np.random.choice([-1.0, 1.0], 3) * nig_rot
         euler_angles = tf.transformations.euler_from_quaternion(quat)
-        new_angles = euler_angles + v
+
+
+        new_translation,new_euler_angles = computeNoise(translation,euler_angles,noise_trans,noise_rot)
 
         # Replace the original atomic transformations by the new noisy ones
-        new_quat = tf.transformations.quaternion_from_euler(
-            new_angles[0], new_angles[1], new_angles[2])
+        new_quat = tf.transformations.quaternion_from_euler(new_euler_angles[0], new_euler_angles[1], new_euler_angles[2])
         dataset['collections'][selected_collection_key]['transforms'][transform_key]['quat'] = new_quat
-        dataset['collections'][selected_collection_key]['transforms'][transform_key]['trans'] = list(
-            new_translation)
+        dataset['collections'][selected_collection_key]['transforms'][transform_key]['trans'] = list(new_translation)
 
         # Copy randomized transform to all collections
         for collection_key, collection in dataset['collections'].items():
@@ -902,26 +965,18 @@ def addNoiseToTF(dataset, selected_collection_key, calibration_parent, calibrati
 
         for collection_key, collection in dataset["collections"].items():
 
-            # Get original transformation
             quat = dataset['collections'][collection_key]['transforms'][transform_key]['quat']
-            translation = dataset['collections'][collection_key]['transforms'][transform_key][
-                'trans']
+            translation = dataset['collections'][collection_key]['transforms'][transform_key]['trans']
 
-            # Add noise to the 6 pose parameters
-            v = np.random.uniform(-1.0, 1.0, 3)
-            v = v / np.linalg.norm(v)
-            new_translation = translation + v * nig_trans
-
-            v = np.random.choice([-1.0, 1.0], 3) * nig_rot
             euler_angles = tf.transformations.euler_from_quaternion(quat)
-            new_angles = euler_angles + v
+
+            new_translation,new_euler_angles = computeNoise(translation,euler_angles,noise_trans,noise_rot)
+
+            new_quat = tf.transformations.quaternion_from_euler(new_euler_angles[0], new_euler_angles[1], new_euler_angles[2])
 
             # Replace the original atomic transformations by the new noisy ones
-            new_quat = tf.transformations.quaternion_from_euler(
-                new_angles[0], new_angles[1], new_angles[2])
             dataset['collections'][collection_key]['transforms'][transform_key]['quat'] = new_quat
-            dataset['collections'][collection_key]['transforms'][transform_key]['trans'] = list(
-                new_translation)
+            dataset['collections'][collection_key]['transforms'][transform_key]['trans'] = list(new_translation)
 
 
 def copyTFToDataset(calibration_parent, calibration_child, source_dataset, target_dataset):

--- a/atom_core/src/atom_core/naming.py
+++ b/atom_core/src/atom_core/naming.py
@@ -12,6 +12,8 @@ def generateName(name, prefix='', suffix='', separator='_'):
 def generateKey(parent, child, suffix=''):
     return parent + '-' + child + suffix
 
+def generateCollectionKey(collection_number):
+    return f"{collection_number:03d}"
 
 def generateLabeledTopic(topic, collection_key=None, type='2d', suffix=''):
     """Returns a standarized string for labeled sensor msg topics.

--- a/atom_evaluation/scripts/other_calibrations/cv_eye_to_hand.py
+++ b/atom_evaluation/scripts/other_calibrations/cv_eye_to_hand.py
@@ -26,7 +26,7 @@ from colorama import init as colorama_init
 
 from atom_calibration.calibration.visualization import getCvImageFromCollectionSensor
 from atom_core.atom import getChain, getTransform
-from atom_core.dataset_io import addNoiseToInitialGuess, filterCollectionsFromDataset, loadResultsJSON, saveAtomDataset, addNoiseToJointParameters
+from atom_core.dataset_io import addNoiseToInitialGuess, filterCollectionsFromDataset, loadResultsJSON, saveAtomDataset, addBiasToJointParameters
 from atom_core.geometry import matrixToTranslationRotation, translationRotationToTransform, traslationRodriguesToTransform, translationQuaternionToTransform
 from atom_core.naming import generateKey
 from atom_core.transformations import compareTransforms
@@ -136,7 +136,7 @@ def main():
     # --- Add noise to the joint parameters to be calibrated.
     # ---------------------------------------
     addNoiseToInitialGuess(dataset, args, selected_collection_key)
-    addNoiseToJointParameters(dataset, args)
+    addBiasToJointParameters(dataset, args)
 
     # Apply new joint values to the tfs
     if args['joint_bias_names'] is not None:

--- a/atom_evaluation/scripts/other_calibrations/cv_eye_to_hand_robot_world.py
+++ b/atom_evaluation/scripts/other_calibrations/cv_eye_to_hand_robot_world.py
@@ -26,7 +26,7 @@ from colorama import init as colorama_init
 
 from atom_calibration.calibration.visualization import getCvImageFromCollectionSensor
 from atom_core.atom import getChain, getTransform
-from atom_core.dataset_io import addNoiseToInitialGuess, filterCollectionsFromDataset, loadResultsJSON, saveAtomDataset, addNoiseToJointParameters
+from atom_core.dataset_io import addNoiseToInitialGuess, filterCollectionsFromDataset, loadResultsJSON, saveAtomDataset, addBiasToJointParameters
 from atom_core.geometry import matrixToTranslationRotation, translationRotationToTransform, traslationRodriguesToTransform, translationQuaternionToTransform
 from atom_core.naming import generateKey
 from atom_core.transformations import compareTransforms
@@ -136,7 +136,7 @@ def main():
     # --- Add noise to the joint parameters to be calibrated.
     # ---------------------------------------
     addNoiseToInitialGuess(dataset, args, selected_collection_key)
-    addNoiseToJointParameters(dataset, args)
+    addBiasToJointParameters(dataset, args)
 
     # Apply new joint values to the tfs
     if args['joint_bias_names'] is not None:

--- a/atom_examples/softbot/softbot_calibration/urdf/optimized.urdf.xacro
+++ b/atom_examples/softbot/softbot_calibration/urdf/optimized.urdf.xacro
@@ -373,7 +373,7 @@
     <child link="lidar3d_plate_link"/>
   </joint>
   <joint name="lidar3d_base_mount_joint" type="fixed">
-    <origin xyz="-0.0015142375046177249 -0.0022052142273190152 -0.000283564068925264" rpy="-0.007757658250765604 0.0009838709879697281 -0.014847674947914611"/>
+    <origin xyz="0.03716082344930228 -0.27220696054487664 0.061596273221005735" rpy="-0.05298232658801819 -0.03810670333805793 -0.10759100238230218"/>
     <parent link="lidar3d_plate_link"/>
     <child link="lidar3d_base_link"/>
   </joint>
@@ -493,7 +493,7 @@
     <selfCollide>false</selfCollide>
   </gazebo>
   <joint name="front_left_camera_rgb_joint" type="fixed">
-    <origin xyz="-4.399872653456163e-16 -0.04499999999999956 3.1045954087761856e-16" rpy="-4.440829884921592e-16 4.4301780635402403e-16 4.438903032319087e-16"/>
+    <origin xyz="-4.4406205425347153e-16 -0.045000000000000435 -3.3859777840638286e-16" rpy="-2.6170137566262974e-16 -1.890031503105939e-16 -4.440892059486435e-16"/>
     <parent link="front_left_camera_link"/>
     <child link="front_left_camera_rgb_frame"/>
   </joint>
@@ -586,7 +586,7 @@
     <selfCollide>false</selfCollide>
   </gazebo>
   <joint name="front_right_camera_rgb_joint" type="fixed">
-    <origin xyz="0.002030911322794242 -0.03938584552044518 -1.2175099096372358e-05" rpy="-0.005222638857532736 0.001007139992505166 -0.0037596367537089353"/>
+    <origin xyz="-0.6754329952328235 0.01920420891565159 -0.37662191151245966" rpy="0.1461866602192413 -0.12509500646354754 -0.1929261388257878"/>
     <parent link="front_right_camera_link"/>
     <child link="front_right_camera_rgb_frame"/>
   </joint>

--- a/atom_examples/softbot/softbot_calibration/urdf/optimized_w_pattern.urdf.xacro
+++ b/atom_examples/softbot/softbot_calibration/urdf/optimized_w_pattern.urdf.xacro
@@ -373,7 +373,7 @@
     <child link="lidar3d_plate_link"/>
   </joint>
   <joint name="lidar3d_base_mount_joint" type="fixed">
-    <origin xyz="-0.0015142375046177249 -0.0022052142273190152 -0.000283564068925264" rpy="-0.007757658250765604 0.0009838709879697281 -0.014847674947914611"/>
+    <origin xyz="0.03716082344930228 -0.27220696054487664 0.061596273221005735" rpy="-0.05298232658801819 -0.03810670333805793 -0.10759100238230218"/>
     <parent link="lidar3d_plate_link"/>
     <child link="lidar3d_base_link"/>
   </joint>
@@ -493,7 +493,7 @@
     <selfCollide>false</selfCollide>
   </gazebo>
   <joint name="front_left_camera_rgb_joint" type="fixed">
-    <origin xyz="-4.399872653456163e-16 -0.04499999999999956 3.1045954087761856e-16" rpy="-4.440829884921592e-16 4.4301780635402403e-16 4.438903032319087e-16"/>
+    <origin xyz="-4.4406205425347153e-16 -0.045000000000000435 -3.3859777840638286e-16" rpy="-2.6170137566262974e-16 -1.890031503105939e-16 -4.440892059486435e-16"/>
     <parent link="front_left_camera_link"/>
     <child link="front_left_camera_rgb_frame"/>
   </joint>
@@ -586,7 +586,7 @@
     <selfCollide>false</selfCollide>
   </gazebo>
   <joint name="front_right_camera_rgb_joint" type="fixed">
-    <origin xyz="0.002030911322794242 -0.03938584552044518 -1.2175099096372358e-05" rpy="-0.005222638857532736 0.001007139992505166 -0.0037596367537089353"/>
+    <origin xyz="-0.6754329952328235 0.01920420891565159 -0.37662191151245966" rpy="0.1461866602192413 -0.12509500646354754 -0.1929261388257878"/>
     <parent link="front_right_camera_link"/>
     <child link="front_right_camera_rgb_frame"/>
   </joint>
@@ -655,7 +655,7 @@
     </visual>
   </link>
   <joint name="world-pattern_link" type="fixed">
-    <origin xyz="1.273180549764564 0.5275071795462576 0.9180241714021727" rpy="-1.57238029953394 -0.7458089302748174 -1.6092354412755343"/>
+    <origin xyz="1.1763285302817843 0.6949119593244414 0.7637724865844582" rpy="-1.4378439431950503 -0.421493318623612 -1.8393927091040134"/>
     <parent link="world"/>
     <child link="pattern_link"/>
   </joint>


### PR DESCRIPTION
Hey, this PR comes as a request from #1006.

It is a sub-PR of #989, containing a smaller set of features.

### Features :

- Add noise to a specific transformation.
- Overhaul of noise adding mechanism ( Refactor only, functionality remains the same).
- Rotation noise now uses uniform distribution instead of choice. https://github.com/lardemua/atom/blob/c5710116d1528e7162133a0a3c7f87c6435cacd4/atom_core/src/atom_core/dataset_io.py#L923-L924

This was the least amount of features I could add to implement specific transformation noise. There were implemented only the strictly necessary dependencies.

I tested with Softbot and it worked well. I used the `-ctgt' flag to ensure the noise added was correct.

A MWE example to test the feature would be something like this. Any softbot dataset shall work as long as the most recent `config.yml` is used. The one in atom examples works.

```bash
rosrun atom_calibration calibrate \                                                                                                         
-json ${Dataset_of_Choice} \                                                                                                                   
-v  -ctgt \                                                                                                                                    
-nig 0.1 0.1 \                                                                                                                           
-ntfv 0.1 0.1 \                                                                                                                                
-ntfl "world:base_footprint"                                                                                                                  
```


